### PR TITLE
fix(pnpm): migrate build settings to pnpm 11 allowBuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
 	"version": "0.0.0",
 	"private": true,
 	"license": "Apache-2.0",
-	"packageManager": "pnpm@10.34.5",
+	"packageManager": "pnpm@11.15.1",
 	"engines": {
 		"node": "24.18.0",
-		"pnpm": "10.34.5",
+		"pnpm": "11.15.1",
 		"npm": "USE_PNPM"
 	},
 	"scripts": {
@@ -34,8 +34,5 @@
 		"typescript": "7.0.2",
 		"vitest": "3.2.7",
 		"wrangler": "4.112.0"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": ["esbuild", "sharp", "workerd"]
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 ---
+engineStrict: true
 allowBuilds:
   esbuild: true
   sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+---
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Problem

Renovate's pnpm major-update PR #249 fails CI with `ERR_PNPM_IGNORED_BUILDS`.

The root cause is a pnpm 11 breaking change:

- pnpm 11 no longer reads the `pnpm` field in `package.json`.
- `onlyBuiltDependencies` was removed and replaced by the `allowBuilds` map in `pnpm-workspace.yaml`.

As a result the `esbuild` / `sharp` / `workerd` build scripts (transitive devDependencies from `wrangler` / `@cloudflare/vitest-pool-workers`) are treated as ignored builds and `pnpm install` aborts.

`main` currently stays green only because the CI pnpm store cache restores the pre-built artifacts and skips the build step. A lockfile change (e.g. `lockFileMaintenance`) or a cache eviction (~7 days) would break `main` as well — CI already runs pnpm `11.15.1` via aqua (`.aqua.yml`), so this is not hypothetical.

## Changes

- Add `pnpm-workspace.yaml` with `allowBuilds` for `esbuild` / `sharp` / `workerd` (equivalent to the old `onlyBuiltDependencies` allowlist).
- Remove the now-ignored `pnpm` field from `package.json`.
- Align `packageManager` and `engines.pnpm` to `11.15.1` to match the aqua `pnpm/pnpm` binary actually used in CI (the repo has `engine-strict = true`).

## Verification

- `pnpm install --frozen-lockfile` (pnpm 11.15.1): no `ERR_PNPM_IGNORED_BUILDS`, no `pnpm field ignored` warning, and the `esbuild` / `sharp` / `workerd` build scripts run. No lockfile diff.
- `pnpm run lint` and `pnpm run test` pass.

## Note on #249

Once `packageManager` is `11.15.1` on `main`, Renovate's #249 (which proposes `11.15.0`) becomes stale and should be auto-closed / rebased to a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
