### PR TITLE
fix(renovate): group node major updates into one PR

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -13,7 +13,8 @@
 		{
 			"groupName": "node",
 			"matchPackageNames": ["node", "nodejs/node"],
-			"versioning": "node"
+			"versioning": "node",
+			"separateMajorMinor": false
 		},
 		{
 			"groupName": "pnpm",


### PR DESCRIPTION
## Problem

Node.js is managed in two places and grouped under `groupName: "node"` in `.renovaterc.json`:

- `.aqua.yml`: `nodejs/node` `v24.18.0` (datasource `github-releases`, managed by the `customManagers` regex).
- `package.json`: `engines.node` `24.18.0` (npm datasource, depName `node`).

However, `config:best-practices` enables `separateMajorMinor`, so **major updates are split into a separate branch**, producing two separate PRs for the next major bump — the same root cause that broke the pnpm major update (#249 / #404). The versions currently match (`24.18.0`), but a major bump would diverge across two PRs.

## Change

Add `separateMajorMinor: false` to the node-scoped `packageRule` so majors are grouped together and land in a single PR alongside the aqua bump. This overrides the `separateMajorMinor: true` inherited from `config:best-practices` for node packages only; the pnpm rule is unchanged.

## Verification

- `renovate-config-validator .renovaterc.json`: validated successfully.
- `.renovaterc.json` passes `biome check` with the aqua-pinned biome `v1.9.4`.
- Runtime behavior (node major bundled into one PR) will be confirmed on the next Renovate run / Dependency Dashboard.

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)