### PR TITLE
fix(renovate): group pnpm major updates into one PR

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -18,7 +18,8 @@
 		},
 		{
 			"groupName": "pnpm",
-			"matchPackageNames": ["pnpm", "pnpm/pnpm"]
+			"matchPackageNames": ["pnpm", "pnpm/pnpm"],
+			"separateMajorMinor": false
 		}
 	],
 	"customManagers": [


### PR DESCRIPTION
## Problem

pnpm is managed in two places (aqua `pnpm/pnpm` and `package.json` `packageManager` / `engines.pnpm`) and grouped under `groupName: "pnpm"`. However, `config:best-practices` enables `separateMajorMinor`, so major updates are split into a separate branch (`renovate/major-pnpm`), producing two PRs on two different schedules — the root cause that made the aqua bump (#399) and the `packageManager` bump (#249) land separately and then broke #249's CI (#404).

## Change

Add `separateMajorMinor: false` to the pnpm-scoped `packageRule` so majors are grouped together and land in a single PR, matching the node rule (#406 / d16e5d7).

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)