### PR TITLE
fix: return controlled JSON error on GitHub API failure in fetch handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,15 +47,24 @@ export default {
 			);
 		}
 
-		const installationOctokit =
-			await app.getInstallationOctokit(installationId);
+		try {
+			const installationOctokit =
+				await app.getInstallationOctokit(installationId);
 
-		const { data } = await installationOctokit.request(
-			"GET /installation/repositories",
-		);
+			const { data } = await installationOctokit.request(
+				"GET /installation/repositories",
+			);
 
-		return new Response(JSON.stringify(data), {
-			headers: { "Content-Type": "application/json" },
-		});
+			return new Response(JSON.stringify(data), {
+				headers: { "Content-Type": "application/json" },
+			});
+		} catch (error) {
+			console.error(error);
+			const message = error instanceof Error ? error.message : "Unknown error";
+			return new Response(JSON.stringify({ error: message }), {
+				status: 502,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
 	},
 } satisfies ExportedHandler<Env>;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -93,4 +93,28 @@ describe("GitHub Apps API worker", () => {
 			missing: ["INSTALLATION_ID"],
 		});
 	});
+
+	it("returns a 502 JSON error response when the GitHub API call fails", async () => {
+		const mockGetInstallationOctokit = vi.fn().mockResolvedValue({
+			request: vi.fn().mockRejectedValue(new Error("GitHub API failure")),
+		});
+		vi.mocked(App).mockImplementation(
+			class {
+				getInstallationOctokit = mockGetInstallationOctokit;
+			} as unknown as typeof App,
+		);
+
+		const request = new Request("http://example.com") as Request<
+			unknown,
+			IncomingRequestCfProperties
+		>;
+		const ctx = createExecutionContext();
+
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(502);
+		expect(response.headers.get("Content-Type")).toBe("application/json");
+		expect(await response.json()).toEqual({ error: "GitHub API failure" });
+	});
 });


### PR DESCRIPTION
## Summary
- Wraps the `app.getInstallationOctokit()` + `installationOctokit.request()` calls in `src/index.ts`'s `fetch` handler in a try/catch block.
- On failure (auth error, rate limit, network failure, etc.), the error is logged via `console.error` and a controlled `502` JSON response `{ "error": "<message>" }` is returned instead of letting the exception propagate into an uncaught, generic Workers 500.
- The happy-path behavior (200 JSON response with installation repositories) is unchanged.
- Does **not** touch the missing-`APP_ID`/`PRIVATE_KEY` validation — that's tracked separately in issue #411.

Closes #410

## Test plan
- [x] Added a new test in `test/index.spec.ts` that mocks `installationOctokit.request` to reject, and asserts the response is a `502` with JSON body `{ "error": "GitHub API failure" }`.
- [x] `pnpm run test` — both tests pass (existing happy-path test + new error-path test).
- [x] `npx @biomejs/biome@1.9.4 check --write .` — no issues, no changes needed.
- [x] `npx oxlint@0.16.0` — 0 warnings, 0 errors.
- [ ] `npx tsc --noEmit` — pre-existing, unrelated errors about `APP_ID`/`PRIVATE_KEY`/`INSTALLATION_ID` not existing on `Env` (caused by `wrangler.toml` not declaring these in `[vars]`; reproduced identically on `main` before this change, confirmed via `git stash`). Not introduced by this PR.

Note: local sandbox Node version (22.22.2) doesn't match the repo's pinned `24.18.0`, so `pnpm install`/`pnpm run test` were run with `engine-strict` disabled for this environment only; no config files were changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_