### PR TITLE
Validate required secrets (APP_ID/PRIVATE_KEY/INSTALLATION_ID) upfront

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,21 @@ import { App } from "@octokit/app";
 export default {
 	// eslint-disable-next-line no-unused-vars
 	async fetch(request, env, ctx): Promise<Response> {
+		const missing: string[] = [];
+		if (!env.APP_ID) missing.push("APP_ID");
+		if (!env.PRIVATE_KEY) missing.push("PRIVATE_KEY");
+		if (!env.INSTALLATION_ID) missing.push("INSTALLATION_ID");
+
+		if (missing.length > 0) {
+			return new Response(
+				JSON.stringify({ error: "Missing required configuration", missing }),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		}
+
 		const app = new App({
 			appId: env.APP_ID,
 			privateKey: env.PRIVATE_KEY,
@@ -23,7 +38,13 @@ export default {
 
 		const installationId = Number(env.INSTALLATION_ID);
 		if (Number.isNaN(installationId)) {
-			return new Response("Invalid INSTALLATION_ID", { status: 400 });
+			return new Response(
+				JSON.stringify({ error: "Invalid INSTALLATION_ID" }),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
 		}
 
 		const installationOctokit =

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -51,7 +51,10 @@ describe("GitHub Apps API worker", () => {
 	});
 
 	it("returns a 400 config error when APP_ID and PRIVATE_KEY are missing", async () => {
-		const request = new Request("http://example.com");
+		const request = new Request("http://example.com") as Request<
+			unknown,
+			IncomingRequestCfProperties
+		>;
 		const ctx = createExecutionContext();
 
 		const response = await worker.fetch(
@@ -70,7 +73,10 @@ describe("GitHub Apps API worker", () => {
 	});
 
 	it("returns a 400 config error when INSTALLATION_ID is missing", async () => {
-		const request = new Request("http://example.com");
+		const request = new Request("http://example.com") as Request<
+			unknown,
+			IncomingRequestCfProperties
+		>;
 		const ctx = createExecutionContext();
 
 		const response = await worker.fetch(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -49,4 +49,42 @@ describe("GitHub Apps API worker", () => {
 		expect(response.headers.get("Content-Type")).toBe("application/json");
 		expect(await response.json()).toEqual(mockRepositoriesData);
 	});
+
+	it("returns a 400 config error when APP_ID and PRIVATE_KEY are missing", async () => {
+		const request = new Request("http://example.com");
+		const ctx = createExecutionContext();
+
+		const response = await worker.fetch(
+			request,
+			{ ...mockEnv, APP_ID: "", PRIVATE_KEY: "" },
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(400);
+		expect(response.headers.get("Content-Type")).toBe("application/json");
+		expect(await response.json()).toEqual({
+			error: "Missing required configuration",
+			missing: ["APP_ID", "PRIVATE_KEY"],
+		});
+	});
+
+	it("returns a 400 config error when INSTALLATION_ID is missing", async () => {
+		const request = new Request("http://example.com");
+		const ctx = createExecutionContext();
+
+		const response = await worker.fetch(
+			request,
+			{ ...mockEnv, INSTALLATION_ID: "" },
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(400);
+		expect(response.headers.get("Content-Type")).toBe("application/json");
+		expect(await response.json()).toEqual({
+			error: "Missing required configuration",
+			missing: ["INSTALLATION_ID"],
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- The `fetch` handler previously only validated that `INSTALLATION_ID` was numeric, but proceeded to construct `App` and call the GitHub API even when `APP_ID` and/or `PRIVATE_KEY` were unset/empty, resulting in a confusing error surfaced from deep inside `@octokit/app` rather than a clear configuration error.
- Added an upfront check that collects which of `APP_ID`, `PRIVATE_KEY`, and `INSTALLATION_ID` are missing/empty and, if any are missing, returns a `400` JSON response: `{ "error": "Missing required configuration", "missing": [...] }`.
- The existing `Number.isNaN(installationId)` numeric-format check for `INSTALLATION_ID` is unchanged (still runs after the presence check), and its response was converted to JSON for consistency with the rest of the handler.
- Scope is limited to presence validation only, per issue #411; no try/catch was added around the GitHub API calls (that's tracked separately in #410).

## Test plan
- [x] `pnpm run test` (vitest) — all 3 tests pass, including 2 new tests covering: missing `APP_ID`/`PRIVATE_KEY` returns a 400 config error, and missing `INSTALLATION_ID` returns a 400 config error.
- [x] `npx @biomejs/biome@1.9.4 check --write .` — no issues.
- [x] `npx oxlint@0.16.0` — 0 warnings, 0 errors.
- [x] `npx tsc --noEmit` — no type errors.
- [ ] Real `pnpm run lint` (aqua-managed biome/oxlint) — not runnable in this sandbox (aqua CLI not installed); ran pinned versions via npx instead as a best-effort substitute. CI will run the real versions.

Closes #411


---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_