### PR TITLE
Clean up leftover template code in src/index.ts and tsconfig.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,9 @@
-/**
- * Welcome to Cloudflare Workers! This is your first worker.
- *
- * - Run `npm run dev` in your terminal to start a development server
- * - Open a browser tab at http://localhost:8787/ to see your worker in action
- * - Run `npm run deploy` to publish your worker
- *
- * Bind resources to your worker in `wrangler.toml`. After adding bindings, a type definition for the
- * `Env` object can be regenerated with `npm run cf-typegen`.
- *
- * Learn more at https://developers.cloudflare.com/workers/
- */
+// GitHub Apps API playground worker — returns the installation's repository list as JSON.
 
 import { App } from "@octokit/app";
 
 export default {
-	// eslint-disable-next-line no-unused-vars
-	async fetch(request, env, ctx): Promise<Response> {
+	async fetch(_request, env, _ctx): Promise<Response> {
 		const missing: string[] = [];
 		if (!env.APP_ID) missing.push("APP_ID");
 		if (!env.PRIVATE_KEY) missing.push("PRIVATE_KEY");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,6 @@
 		"target": "es2022",
 		/* Specify a set of bundled library declaration files that describe the target runtime environment. */
 		"lib": ["es2024"],
-		/* Specify what JSX code is generated. */
-		"jsx": "react-jsx",
 
 		/* Specify what module code is generated. */
 		"module": "es2022",


### PR DESCRIPTION
## Summary
- Replaced the Cloudflare-generated template header comment in `src/index.ts` (which referenced `npm run dev`/`npm run deploy`/`npm run cf-typegen`, none of which exist in this repo) with a one-line description of what the worker does.
- Removed the meaningless `// eslint-disable-next-line no-unused-vars` comment — this project uses oxlint + Biome, not ESLint — and instead prefixed the genuinely-unused `request` and `ctx` handler parameters with underscores (`_request`, `_ctx`) so they're clearly intentional. `env` is unchanged since it's used.
- Removed the unused `"jsx": "react-jsx"` option from `tsconfig.json`; this project has no JSX/React code.

No runtime behavior changes.

Closes #415

## Test plan
- `pnpm run test` — 1 test file, 1 test, passed.
- `npx tsc --noEmit` — no errors.
- `npx @biomejs/biome@1.9.4 check --write .` — checked 9 files, no fixes needed.
- `npx oxlint@0.16.0` — 0 warnings, 0 errors.
- Note: local sandbox has Node v22.22.2 while the repo pins Node 24.18.0 via `engines`; installs/tests were run with `PNPM_CONFIG_ENGINE_STRICT=false` to bypass the engine check. CI should validate with the pinned Node version. `wrangler types` was run once to sanity-check the worker but its regenerated `worker-configuration.d.ts` was reverted since it's unrelated to this issue's scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_