### PR TITLE
ci: run CI on pull_request and cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@
 name: CI
 on:
   push:
+    branches: [main]
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary
- Add a `pull_request:` trigger to `.github/workflows/ci.yml` so CI runs on pull requests (including ones from forks), not just on push.
- Scope the existing `push:` trigger to `branches: [main]` so feature-branch pushes don't double-trigger CI once `pull_request` also fires.
- Add a top-level `concurrency:` block (`group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) so consecutive pushes to the same branch/PR cancel older in-flight runs instead of piling up.
- No changes to `permissions:` or the job steps.

Closes #417

## Test plan
- [x] Validated YAML syntax with `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses cleanly.
- [x] Visually double-checked indentation matches the file's existing 2-space style.
- [x] `pnpm install --ignore-scripts` and `pnpm run test` run clean locally (workflow-only change, no-op as expected — 1 test file / 1 test passing).
- [ ] Since this repo doesn't otherwise exercise PR-triggered CI yet, this PR itself is the first real test of the `pull_request` trigger — please confirm a CI run actually fires on this PR once it's opened (and that a follow-up push cancels the earlier run via the new concurrency group).


---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_