### PR TITLE
Document worker behavior/config in README, add .dev.vars.example

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,12 @@
+# Copy this file to `.dev.vars` and fill in real values for local development.
+# `.dev.vars` is read by `wrangler dev` and is gitignored — never commit it.
+
+# The GitHub App's ID.
+APP_ID=123456
+
+# The GitHub App's private key (PEM format). Keep the literal "\n" line breaks
+# when storing a multi-line key on a single line.
+PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+
+# The ID of the installation whose repositories should be listed.
+INSTALLATION_ID=12345678

--- a/README.md
+++ b/README.md
@@ -20,6 +20,46 @@ To run:
 pnpm run dev
 ```
 
+## What this worker does
+
+This worker authenticates as a GitHub App (via `@octokit/app`), gets an installation
+access token for a specific installation, and calls `GET /installation/repositories`.
+It returns that installation's repository list as JSON.
+
+## Configuration
+
+The worker reads the following secrets from `env` (see `src/index.ts`):
+
+- `APP_ID` — the GitHub App's ID.
+- `PRIVATE_KEY` — the GitHub App's private key (PEM format).
+- `INSTALLATION_ID` — the ID of the installation whose repositories should be listed.
+
+`wrangler.toml` also defines a plain (non-secret) variable under `[vars]`:
+
+- `MODE` — currently set to `"development"`.
+
+### Deployed secrets
+
+For a deployed worker, set the secrets with `wrangler secret put`:
+
+```bash
+wrangler secret put APP_ID
+wrangler secret put PRIVATE_KEY
+wrangler secret put INSTALLATION_ID
+```
+
+### Local development
+
+For `pnpm run dev` (which runs `wrangler dev`), wrangler reads secrets from a local
+`.dev.vars` file instead. Copy `.dev.vars.example` to `.dev.vars` and fill in your own
+values:
+
+```bash
+cp .dev.vars.example .dev.vars
+```
+
+`.dev.vars` is gitignored and should never be committed.
+
 # Reference
 
 - [octokit/app.js: GitHub Apps toolset for Node.js](https://github.com/octokit/app.js/)


### PR DESCRIPTION
## Summary

- Add a "What this worker does" section to `README.md` explaining that the worker authenticates as a GitHub App and returns the target installation's repository list as JSON (`GET /installation/repositories`).
- Add a "Configuration" section documenting the three required secrets (`APP_ID`, `PRIVATE_KEY`, `INSTALLATION_ID`), how to set them for a deployed worker via `wrangler secret put`, how to set them locally via `.dev.vars`, and a mention of the `MODE` variable under `wrangler.toml`'s `[vars]`.
- Add `.dev.vars.example` at the repo root with placeholder values and comments for local development, referenced from the new README section.

Existing "## Setup", "## Running", and "# Reference" sections are unchanged.

Closes #416

## Test plan

- [x] `pnpm install --ignore-scripts` (had to pass `PNPM_CONFIG_ENGINE_STRICT=false` / `--config.engine-strict=false` locally since the sandbox's Node is v22 vs the repo's pinned 24.18.0; not a repo issue)
- [x] `pnpm run test` — 1 test file, 1 test, passed (docs-only change, no-op as expected)
- [x] `npx --yes @biomejs/biome@1.9.4 check --write .` — no issues, no fixes needed
- [ ] Real `biome`/`oxlint` via `pnpm run lint` not run locally (those binaries come from `aqua`, which isn't installed in this sandbox); CI will run the pinned versions


---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_