### PR TITLE
Ignore local .claude/ runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,7 @@ dist
 # certificate files
 
 *.pem
+
+# Claude Code local runtime artifacts (e.g. agent worktrees)
+
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore`.

## Context
This session used isolated agent worktrees (checked out under `.claude/worktrees/`) to work on several other issues in parallel, each producing its own separate PR. Those worktree checkouts are local-only runtime state and shouldn't be tracked by git, so they're now ignored.

## Test plan
- N/A (gitignore-only change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_