### PR TITLE
ci: add tsc type-check step for src and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       uses: ./.github/actions/setup-aqua
     - name: Setup pnpm
       uses: ./.github/actions/setup-pnpm
+    - name: Running Typecheck
+      run: pnpm run typecheck
     - name: Running Lint
       run: pnpm run lint
     - name: Running Test

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"start": "wrangler dev",
 		"deploy": "wrangler deploy",
 		"destroy": "wrangler delete --force",
-		"typegen": "wrangler types && tsc"
+		"typegen": "wrangler types && tsc",
+		"typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json"
 	},
 	"dependencies": {
 		"@octokit/app": "16.1.2"

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -12,10 +12,13 @@ vi.mock("@octokit/app", () => ({
 
 describe("GitHub Apps API worker", () => {
 	const mockEnv = {
+		MODE: "development",
 		APP_ID: "test-app-id",
+		CLIENT_ID: "test-client-id",
+		CLIENT_SECRET: "test-client-secret",
 		PRIVATE_KEY: "test-private-key",
 		INSTALLATION_ID: "12345",
-	};
+	} satisfies Env;
 
 	const mockRepositoriesData = {
 		repositories: [{ name: "test-repo" }],
@@ -26,15 +29,18 @@ describe("GitHub Apps API worker", () => {
 		const mockGetInstallationOctokit = vi.fn().mockResolvedValue({
 			request: vi.fn().mockResolvedValue({ data: mockRepositoriesData }),
 		});
-		App.mockImplementation(
+		vi.mocked(App).mockImplementation(
 			class {
 				getInstallationOctokit = mockGetInstallationOctokit;
-			},
+			} as unknown as typeof App,
 		);
 	});
 
 	it("returns installation repositories as JSON", async () => {
-		const request = new Request("http://example.com");
+		const request = new Request("http://example.com") as Request<
+			unknown,
+			IncomingRequestCfProperties
+		>;
 		const ctx = createExecutionContext();
 
 		const response = await worker.fetch(request, mockEnv, ctx);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,10 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
-		"types": ["@cloudflare/vitest-pool-workers", "../worker-configuration.d.ts"]
+		"types": [
+			"@cloudflare/vitest-pool-workers/types",
+			"../worker-configuration.d.ts"
+		]
 	},
 	"include": ["./**/*.ts", "../worker-configuration.d.ts"],
 	"exclude": []


### PR DESCRIPTION
## Summary
- `ci.yml` only ran `pnpm run lint` and `pnpm run test`; `tsc` was never invoked, and vitest doesn't type-check by default, so type errors could slip through.
- Add a `typecheck` script (`tsc --noEmit && tsc --noEmit -p test/tsconfig.json`) covering both `src` (root `tsconfig.json`) and `test` (`test/tsconfig.json`, which extends the root config and adds `@cloudflare/vitest-pool-workers` + `cloudflare:test` types), and wire it into `ci.yml` as a new "Running Typecheck" step before lint/test.
- The `typecheck` script deliberately does **not** run `wrangler types`: CI has no `.dev.vars`, and regenerating `worker-configuration.d.ts` there would drop the secret bindings (`APP_ID`, `CLIENT_ID`, `CLIENT_SECRET`, `PRIVATE_KEY`, `INSTALLATION_ID`) that are only inferred from a local `.dev.vars` file — producing spurious type errors. The already-committed `worker-configuration.d.ts` is used as-is, consistent with how it's tracked in git today.
- While verifying the new `test` type-check actually runs clean, found and fixed a few latent issues it uncovered (these are required for the new gate to pass without going red on this very change, not scope creep):
  - `test/tsconfig.json`'s `types` entry pointed at `@cloudflare/vitest-pool-workers`, but the installed version exposes the `cloudflare:test` ambient module only via its `/types` subpath export, so the module wasn't resolving at all.
  - `test/index.spec.ts`'s `mockEnv` was missing `MODE`, `CLIENT_ID`, `CLIENT_SECRET` (now `satisfies Env`).
  - `vi.mock`'d `App` lost its mock typing when calling `.mockImplementation(...)` directly; switched to `vi.mocked(App).mockImplementation(...)`.
  - `new Request(...)` infers outgoing `CfProperties`, not the incoming `IncomingRequestCfProperties` the worker's `fetch` handler expects; added an explicit cast.

## Test plan
- `pnpm install --ignore-scripts` (sandbox lacks the `aqua` CLI needed by the real `preinstall` script; also had to pass `--config.engine-strict=false` since the sandbox's Node is v22, not the pinned v24.18.0 — CI itself pins the correct Node via aqua/setup-pnpm and isn't affected).
- `pnpm run typecheck` — passes (`tsc --noEmit` for `src`, `tsc --noEmit -p test/tsconfig.json` for `test`).
- Sanity-checked the gate actually catches errors: introduced a bogus `env.INSTALLATION_ID_DOES_NOT_EXIST` reference in `src/index.ts`, confirmed `pnpm run typecheck` failed with a clear `TS2339`, then reverted it.
- `pnpm run test` — 1 test file, 1 test, passes.
- Best-effort local format/lint (real `biome`/`oxlint` come from `aqua`, not installed here): `npx --yes @biomejs/biome@1.9.4 check --write .` (reformatted 2 files, re-verified typecheck/test still pass) and `npx --yes oxlint@0.16.0` (0 warnings/errors) — CI runs the pinned versions via aqua, so treat this as a secondary signal only.

Closes #412


---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_