### PR TITLE
Make lint:biome check-only so CI fails on unformatted code

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"preinstall:pnpm": "npx -y only-allow pnpm",
 		"fmt": "biome check --write",
 		"lint": "pnpm run lint:biome && pnpm run lint:oxlint",
-		"lint:biome": "biome check --write",
+		"lint:biome": "biome check",
 		"lint:oxlint": "oxlint",
 		"test": "vitest",
 		"test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- `lint:biome` previously ran `biome check --write`, which meant CI silently auto-fixed formatting/import-order drift instead of failing the build. Unformatted code could slip through review because CI would just fix it and pass.
- `lint:biome` and `fmt` were also byte-for-byte identical, so their roles were unclear.
- Dropped `--write` from `lint:biome` (now `biome check`) so `pnpm run lint` (used by CI) is check-only and fails on unformatted code. `fmt` is unchanged and stays the dedicated auto-fix command (`biome check --write`).
- No changes to `.github/workflows/ci.yml` were needed since it already just calls `pnpm run lint`.

Closes #413

## Test plan
- `pnpm install --ignore-scripts` (sandbox lacks the `aqua` CLI needed by the repo's normal `preinstall`)
- `npx --yes @biomejs/biome@1.9.4 check .` → passes cleanly with no fixes needed, confirming the existing source is already Biome-formatted and the check-only script won't break CI
- `npx --yes oxlint@0.16.0` → 0 warnings, 0 errors
- `pnpm run test` (via direct `vitest` invocation, since nested `pnpm run` sub-scripts hit an unrelated sandbox Node-version mismatch against this repo's pinned `engines.node`/`.npmrc` `engine-strict=true`) → 1 test file, 1 test, passed
- Could not run `pnpm run lint` end-to-end in this sandbox because it needs Node 24.18.0 and nested `pnpm run` invocations don't pick up an engine-strict override the way the top-level command does; this is a sandbox limitation unrelated to the change and will run fine in real CI, which pins the correct Node version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_