### PR TITLE
Add proposed CD workflow for automated deploys (for discussion)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,33 @@
+---
+name: CD
+on:
+  push:
+    branches:
+    - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+permissions:
+  contents: read
+jobs:
+  deploy:
+    name: Deploy
+    # Skip cleanly (not fail) until the maintainer configures the
+    # CLOUDFLARE_API_TOKEN repository secret.
+    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: Setup aqua
+      uses: ./.github/actions/setup-aqua
+    - name: Setup pnpm
+      uses: ./.github/actions/setup-pnpm
+    - name: Deploy
+      uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        command: deploy


### PR DESCRIPTION
## Summary

Issue #419 raises deployment automation "for consideration" — it's explicitly framed as an open discussion, not a decided direction. Today deployment is manual only (`pnpm run deploy` via wrangler). This PR proposes **one possible direction**: a new, purely additive `.github/workflows/cd.yml` that automates deploys on push to `main`, using [`cloudflare/wrangler-action`](https://github.com/cloudflare/wrangler-action) (the official Cloudflare Workers deploy action).

Design choices, to make the proposal concrete for discussion:
- Triggers only on `push` to `main` (the default branch).
- Top-level `concurrency` group (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: false`) so deploys queue instead of overlapping, and an in-flight deploy is never cancelled mid-way. Mirrors the concurrency pattern proposed for CI in #417 (not touched here — that's a separate PR).
- `permissions: contents: read` only — no broader scopes than needed to check out the repo.
- Reuses the existing `./.github/actions/setup-aqua` and `./.github/actions/setup-pnpm` composite actions, and pins `actions/checkout` to the same SHA already used in `ci.yml` (`3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`).
- `cloudflare/wrangler-action` is pinned to a full commit SHA with a version comment (`9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0`), matching this repo's existing SHA-pinning convention.
- The `deploy` job is guarded with `if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}` so the workflow shows as cleanly **skipped**, not failed, on every push to `main` until the secret is configured.

`ci.yml` and `wrangler.toml` are intentionally untouched — this is purely a new, additive workflow file.

## Required setup

For this workflow to actually deploy, the maintainer must add a `CLOUDFLARE_API_TOKEN` repository secret (Settings → Secrets and variables → Actions) with a Cloudflare API token scoped for Workers deploys. Until that secret exists, the job's `if` guard causes it to no-op safely (skipped, not failed) on every push to `main` — no action is required to keep the current manual-deploy workflow as-is.

If manual deployment via `pnpm run deploy` is intentional and this automation isn't wanted, this PR can simply be closed — see #419 for the underlying discussion.

## Test plan

Could not run GitHub Actions locally, so I validated what's checkable from the sandbox:
- [x] YAML syntax: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/cd.yml'))"` parses cleanly (same benign `on:` → boolean quirk as `ci.yml` under PyYAML — not an actual issue, GitHub Actions itself parses `on:` correctly).
- [x] Confirmed `ci.yml` and `wrangler.toml` have no diff against `origin/main`.
- [x] `pnpm install --ignore-scripts` and `pnpm run test` still pass (no-op, confirming the change doesn't affect anything else). Note: the sandbox's Node is v22.22.2 vs. this repo's pinned `24.18.0`, so `engine-strict` had to be bypassed locally (`--config.engine-strict=false`) to run install/test — this is a pre-existing sandbox limitation unrelated to this change.
- [ ] Could not actually exercise the workflow end-to-end (no `CLOUDFLARE_API_TOKEN`, and GitHub Actions doesn't run in this sandbox) — the guard condition and `wrangler-action` behavior are unverified beyond documentation/manual review.

Relates to #419

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5fh7kSssk5Qn99cywj4nC)_