### PR TITLE
test: pin auth edge-case behavior after Hono migration (#438)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ This worker authenticates as a GitHub App (via `@octokit/app`), gets an installa
 access token for a specific installation, and calls `GET /installation/repositories`.
 It returns that installation's repository list as JSON.
 
-Routing is handled by [Hono](https://hono.dev/): only `GET /` is served (anything else
-returns a JSON `404`), and an optional `Authorization: Bearer` check is applied via
-Hono's `bearerAuth` middleware when `API_TOKEN` is configured (see below).
+Routing is handled by [Hono](https://hono.dev/): only `GET /` is served, and an optional
+`Authorization: Bearer` check is applied via Hono's `bearerAuth` middleware when
+`API_TOKEN` is configured (see below).
+
+When `API_TOKEN` is unset, any request other than `GET /` returns a JSON `404`. When
+`API_TOKEN` is set, the auth middleware runs before route matching, so an unauthenticated
+request returns `401` (missing or wrong token) or `400` (a malformed, non-`Bearer`
+`Authorization` header) regardless of path or method; a request that passes auth but
+isn't `GET /` still returns the JSON `404`.
 
 ## Configuration
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -215,4 +215,80 @@ describe("GitHub Apps API worker", () => {
 		expect(response.headers.get("Content-Type")).toBe("application/json");
 		expect(await response.json()).toEqual(mockRepositoriesData);
 	});
+
+	// The Hono migration (#438) enforces Bearer auth via a catch-all
+	// `app.use("*")` that runs before route matching, and delegates the header
+	// check to Hono's bearerAuth middleware. Codex flagged two behavior changes
+	// from the pre-Hono exact-match contract (#438 review): auth now runs before
+	// the 404 route guard, and a non-Bearer Authorization header yields 400
+	// instead of 401. Both were accepted as the intended behavior; the tests
+	// below pin it so any future change is deliberate.
+	it("returns 401 for a non-root path when API_TOKEN is set and no Authorization header is sent", async () => {
+		const request = new Request("http://example.com/other") as Request<
+			unknown,
+			IncomingRequestCfProperties
+		>;
+		const ctx = createExecutionContext();
+
+		const response = await worker.fetch(
+			request,
+			{ ...mockEnv, API_TOKEN: "secret-token" },
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({ error: "Unauthorized" });
+	});
+
+	it("returns 401 for a non-GET method when API_TOKEN is set and no Authorization header is sent", async () => {
+		const request = new Request("http://example.com", {
+			method: "POST",
+		}) as Request<unknown, IncomingRequestCfProperties>;
+		const ctx = createExecutionContext();
+
+		const response = await worker.fetch(
+			request,
+			{ ...mockEnv, API_TOKEN: "secret-token" },
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({ error: "Unauthorized" });
+	});
+
+	it("returns 400 when API_TOKEN is set and the Authorization header is not a Bearer token", async () => {
+		const request = new Request("http://example.com", {
+			headers: { Authorization: "Token secret-token" },
+		}) as Request<unknown, IncomingRequestCfProperties>;
+		const ctx = createExecutionContext();
+
+		const response = await worker.fetch(
+			request,
+			{ ...mockEnv, API_TOKEN: "secret-token" },
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "Unauthorized" });
+	});
+
+	it("returns 400 when API_TOKEN is set and the Authorization header is Bearer with no token", async () => {
+		const request = new Request("http://example.com", {
+			headers: { Authorization: "Bearer" },
+		}) as Request<unknown, IncomingRequestCfProperties>;
+		const ctx = createExecutionContext();
+
+		const response = await worker.fetch(
+			request,
+			{ ...mockEnv, API_TOKEN: "secret-token" },
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "Unauthorized" });
+	});
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,8 +27,10 @@ mode = "smart"
 #
 # Optional secret: API_TOKEN
 # If set (via `wrangler secret put API_TOKEN`), requests must send
-# `Authorization: Bearer <API_TOKEN>` or the worker returns 401. Left unset
-# (e.g. local/default dev), the check is skipped entirely. Not declared in
+# `Authorization: Bearer <API_TOKEN>`. A missing or non-matching token returns
+# 401; a malformed, non-`Bearer` `Authorization` header returns 400 (from Hono's
+# bearerAuth). Left unset (e.g. local/default dev), the check is skipped
+# entirely. Not declared in
 # [vars] since it's a secret; add it with `wrangler secret put API_TOKEN`,
 # then regenerate `worker-configuration.d.ts` via `wrangler types` so it's
 # reflected in the generated Env type.


### PR DESCRIPTION
## Summary

Follow-up to the two P2 Codex review comments left on PR #438 (the merged Hono migration). Both flag auth edge cases whose behavior changed under Hono, contrary to that PR's "behavior-preserving" claim:

- **[#438 review 1](https://github.com/takumin/cloudflare-workers-github-apps-playground/pull/438#discussion_r3644202537)** — The auth middleware (`app.use("*")`) runs before route matching, so with `API_TOKEN` set an unauthenticated `GET /other` or `POST /` now returns `401` instead of the previous JSON `404`.
- **[#438 review 2](https://github.com/takumin/cloudflare-workers-github-apps-playground/pull/438#discussion_r3644202543)** — Hono's `bearerAuth` returns `400` (not the previous `401`) for a non-Bearer `Authorization` header (e.g. `Token ...`, or a bare `Bearer` with no token); the `invalidAuthenticationHeader` option only changes the body, not the status.

Both observations are valid when compared against the pre-Hono hand-rolled implementation from PR #432. The decision here is to **accept these `401`/`400` responses as the intended behavior** rather than revert them: no production code changes, only **regression tests that pin the current Hono behavior** so any future change is deliberate and detected by the suite.

## What changed

- **`test/index.spec.ts`**: added the 4 regression tests below (`src/index.ts` is untouched). The intent is documented in a comment on the added block.
  - Non-root path + `API_TOKEN` set + no Authorization header → `401 { "error": "Unauthorized" }`
  - Non-GET method + `API_TOKEN` set + no Authorization header → `401 { "error": "Unauthorized" }`
  - Non-Bearer `Authorization: Token ...` + `API_TOKEN` set → `400 { "error": "Unauthorized" }`
  - Bare `Authorization: Bearer` (no token) + `API_TOKEN` set → `400 { "error": "Unauthorized" }`

## Test plan

- [x] `vitest run` — 14 tests pass (10 existing + 4 new)
- [x] `@biomejs/biome check test/index.spec.ts` — clean
- [x] `oxlint test/ src/` — 0 warnings / 0 errors
- [x] `tsc --noEmit -p test/tsconfig.json` — clean

Note: the sandbox's Node is `v22.22.2` (the repo pins `24.18.0`) and `aqua` isn't available, so install used `pnpm install --ignore-scripts --config.engine-strict=false` and each tool was run via `npx` / the local binary. Please treat CI's normal `pnpm run test` / `pnpm run lint` as authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)